### PR TITLE
Windows fix & Discord intent

### DIFF
--- a/DiscordBotPlugin/DiscordBotPlugin.csproj
+++ b/DiscordBotPlugin/DiscordBotPlugin.csproj
@@ -88,10 +88,6 @@
       <HintPath>H:\AMPDatastore\Instances\Minecraft02\ModuleShared.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>

--- a/DiscordBotPlugin/PluginMain.cs
+++ b/DiscordBotPlugin/PluginMain.cs
@@ -113,8 +113,11 @@ namespace DiscordBotPlugin
         /// <returns></returns>
         public async Task ConnectDiscordAsync(string BotToken)
         {
+            DiscordSocketConfig config = new DiscordSocketConfig { GatewayIntents = GatewayIntents.DirectMessages | GatewayIntents.GuildMessages | GatewayIntents.Guilds };
+
             //init Discord client & command service
-            _client = new DiscordSocketClient();
+            _client = new DiscordSocketClient(config);
+
 
             //attach logs and events
             _client.Log += Log;


### PR DESCRIPTION
- Remove reference to Newtonsoft.Json - not needed.  Fixes known issue running the bot on Windows.  Now no longer needs any additional dll in the plugin folder.
- Add config for Discord connection to use only the intents required