### PR TITLE
Add option to send chat to Discord channel

### DIFF
--- a/DiscordBotPlugin/DiscordBotPlugin.csproj
+++ b/DiscordBotPlugin/DiscordBotPlugin.csproj
@@ -84,9 +84,8 @@
       <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.6.0.0\lib\net461\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="ModuleShared">
-      <HintPath>H:\AMPDatastore\Instances\Minecraft01\ModuleShared.dll</HintPath>
+      <HintPath>H:\AMPDatastore\Instances\ConanExiles01\ModuleShared.dll</HintPath>
       <Private>False</Private>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/DiscordBotPlugin/Settings.cs
+++ b/DiscordBotPlugin/Settings.cs
@@ -106,6 +106,15 @@ namespace DiscordBotPlugin
             [WebSetting("Additional Embed Field Text", "Add an additional field in the info panel embed, put your content here", false)]
             public string AdditionalEmbedFieldText = "";
 
+            [WebSetting("Send Chat to Discord", "Send chat messages to a Discord channel", false)]
+            public bool SendChatToDiscord = false;
+
+            [WebSetting("Chat Discord Channel", "Discord channel name to send chat messages to (if enabled)", false)]
+            public string ChatToDiscordChannel = "";
+
+            [WebSetting("Send Chat from Discord to Server", "Attempt to send chat messages from Discord chat channel to the server (currently only supported for Minecraft)", false)]
+            public bool SendDiscordChatToServer = false;
+
             public Dictionary<string, DateTime> LastSeen = new Dictionary<string, DateTime>();
 
         }


### PR DESCRIPTION
As per feature request #48 

New options added:
  * Send Chat to Discord
  * Chat Discord Channel (name of channel to use)
  * Send Chat from Discord to Server (currently this will only work with Minecraft)

**IMPORTANT:** To use new options, 'Message Content Intent' must be enabled for your bot (configured on https://discord.com/developers/applications/[your application id]/bot).

![image](https://user-images.githubusercontent.com/4540397/235220228-ab214f4c-8197-48fa-bdd9-4310755c30da.png)
