### PR TITLE
Add option for Valheim join code (#59)

### DIFF
--- a/DiscordBotPlugin/PluginMain.cs
+++ b/DiscordBotPlugin/PluginMain.cs
@@ -27,6 +27,9 @@ namespace DiscordBotPlugin
         private List<PlayerPlayTime> playerPlayTimes = new List<PlayerPlayTime>();
         private List<String> consoleOutput = new List<String>();
 
+        //game specific variables
+        private string valheimJoinCode;
+
         public PluginMain(ILogger log, IConfigSerializer config, IPlatformInfo platform,
             IRunningTasksManager taskManager, IApplicationWrapper application, IAMPInstanceInfo AMPInstanceInfo)
         {
@@ -73,6 +76,22 @@ namespace DiscordBotPlugin
                 // Clean the message to avoid code blocks and send it to Discord
                 string clean = e.Message.Replace("`", "'");
                 consoleOutput.Add(clean);
+            }
+
+            if (e.Level == LogLevels.Console.ToString() && _settings.GameSpecificSettings.ValheimJoinCode)
+            {
+                // Define the regular expression pattern to match the desired text and extract the numbers.
+                string pattern = @"join code (\d+)";
+
+                // Use Regex.Match to search for a match of the pattern in the message.
+                Match match = Regex.Match(e.Message, pattern);
+
+                // Check if a match was found.
+                if (match.Success)
+                {
+                    // Extract the captured numbers from the match and store them in the valheimJoinCode variable.
+                    valheimJoinCode = match.Groups[1].Value;
+                }
             }
         }
 
@@ -411,6 +430,12 @@ namespace DiscordBotPlugin
             {
                 string leaderboard = GetPlayTimeLeaderBoard(5, false, null, false);
                 embed.AddField("Top 5 Players by Play Time", leaderboard, false);
+            }
+
+            //if valheim join code enabled and code is logged
+            if(_settings.GameSpecificSettings.ValheimJoinCode && valheimJoinCode != "" && application.State == ApplicationState.Ready)
+            {
+                embed.AddField("Server Join Code", "`" + valheimJoinCode + "`");
             }
 
             //if user has added an additonal embed field, add it

--- a/DiscordBotPlugin/Settings.cs
+++ b/DiscordBotPlugin/Settings.cs
@@ -1,6 +1,7 @@
 ﻿using ModuleShared;
 using System;
 using System.Collections.Generic;
+using System.Net.Configuration;
 
 namespace DiscordBotPlugin
 {
@@ -167,5 +168,13 @@ namespace DiscordBotPlugin
         }
 
         public DiscordBotColoursSettings ColourSettings = new DiscordBotColoursSettings();
+
+        public class DiscordBotGameSpecificSettings : SettingSectionStore
+        {
+            [WebSetting("Valheim Join Code", "Look for Valheim join code and display it in the info panel (restart the server after enabling)", false)]
+                public bool ValheimJoinCode = false;
+        }
+
+        public DiscordBotGameSpecificSettings GameSpecificSettings = new DiscordBotGameSpecificSettings();
     }
 }


### PR DESCRIPTION
Add option to show Valheim join code in info panel. Setting is added to new 'Game Specific' section in settings, this will enable more game specific options if they are requested.

![image](https://github.com/winglessraven/AMP-Discord-Bot/assets/4540397/55eda5a6-17be-4820-bb5d-bd346d83040d)

![image](https://github.com/winglessraven/AMP-Discord-Bot/assets/4540397/19b527a2-22ec-4e30-92db-f9b31574fac3)

![image](https://github.com/winglessraven/AMP-Discord-Bot/assets/4540397/f7373b75-5870-431c-9ede-d5aace5a9217)
