### PR TITLE
Added support for custom bot presence variables

### DIFF
--- a/DiscordBotPlugin/Helpers.cs
+++ b/DiscordBotPlugin/Helpers.cs
@@ -2,8 +2,11 @@
 using ModuleShared;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using static DiscordBotPlugin.PluginMain;
 
@@ -52,10 +55,110 @@ namespace DiscordBotPlugin
             }
 
             string presence = settings.MainSettings.OnlineBotPresence;
+
+            // Built-in variables take priority.
             presence = presence.Replace("{OnlinePlayers}", onlinePlayers.ToString());
-            presence = presence.Replace("{MaximumPlayers}", maximumPlayers.ToString());
+            presence = presence.Replace("{MaximumPlayers}",maximumPlayers.ToString());
+
+            // Replace any remaining variables from BotVariables.json.
+            presence = ReplaceBotVariables(presence);
 
             return presence;
+        }
+
+        private static readonly Regex BotVariablePattern = new Regex(@"\{(?<name>[^{}]+)\}",RegexOptions.Compiled);
+
+        private Dictionary<string, string> ReadBotVariables()
+        {
+            var variables = new Dictionary<string, string>(
+                StringComparer.OrdinalIgnoreCase);
+
+            string filePath = Path.Combine(
+                Environment.CurrentDirectory,
+                "BotVariables.json");
+
+            if (!File.Exists(filePath))
+            {
+                log.Debug($"Bot variables file does not exist: {filePath}");
+                return variables;
+            }
+
+            try
+            {
+                using FileStream stream = new FileStream(
+                    filePath,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete);
+
+                using JsonDocument document = JsonDocument.Parse(
+                    stream,
+                    new JsonDocumentOptions
+                    {
+                        AllowTrailingCommas = true,
+                        CommentHandling = JsonCommentHandling.Skip
+                    });
+
+                if (document.RootElement.ValueKind != JsonValueKind.Object)
+                {
+                    log.Error(
+                        $"BotVariables.json must contain a JSON object: {filePath}");
+
+                    return variables;
+                }
+
+                foreach (JsonProperty property in document.RootElement.EnumerateObject())
+                {
+                    string value = property.Value.ValueKind switch
+                    {
+                        JsonValueKind.String => property.Value.GetString() ?? string.Empty,
+                        JsonValueKind.Null => string.Empty,
+                        JsonValueKind.Number or
+                        JsonValueKind.True or
+                        JsonValueKind.False => property.Value.GetRawText(),
+
+                        _ => property.Value.GetRawText()
+                    };
+
+                    variables[property.Name] = value;
+                }
+            }
+            catch (JsonException ex)
+            {
+                log.Error(
+                    $"BotVariables.json contains invalid JSON: {ex.Message}");
+            }
+            catch (IOException ex)
+            {
+                log.Error(
+                    $"Unable to read BotVariables.json: {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                log.Error(
+                    $"Access denied when reading BotVariables.json: {ex.Message}");
+            }
+
+            return variables;
+        }
+
+        private string ReplaceBotVariables(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return input;
+            }
+
+            Dictionary<string, string> variables = ReadBotVariables();
+
+            return BotVariablePattern.Replace(input, match =>
+            {
+                string variableName = match.Groups["name"].Value;
+
+                return variables.TryGetValue(variableName, out string? value)
+                    ? value
+                    : match.Value;
+            });
         }
 
         public string GetPlayTimeLeaderBoard(int placesToShow, bool playerSpecific, string playerName, bool fullList, bool webPanel)

--- a/DiscordBotPlugin/Settings.cs
+++ b/DiscordBotPlugin/Settings.cs
@@ -106,7 +106,7 @@ namespace DiscordBotPlugin
             [WebSetting("Display Online Player List", "Display online player list in the info panel - if not compatible with the server nothing will show", false, Subcategory: "Server Info:page_info:2")]
             public bool ShowOnlinePlayers = false;
 
-            [WebSetting("Online Server Bot Presence Text", "Change the presence text when application is running, use {OnlinePlayers} and {MaximumPlayers} as variables", false, Subcategory: "Misc:more_vert:7")]
+            [WebSetting("Online Server Bot Presence Text", "Change the presence text when application is running, use {OnlinePlayers} and {MaximumPlayers} as variables. Custom variables can also be used - to do this create a 'BotVariables.json' file in the instance folder. Variable name is the key, result is the value, e.g. {test} would read '\"test\": \"result\"'", false, Subcategory: "Misc:more_vert:7")]
             public string OnlineBotPresence = "";
 
             [WebSetting("Change Displayed Status", "Replace the default AMP status with your own - key is the AMP value, value is the replacement - possible values listed on the [Wiki](https://github.com/winglessraven/AMP-Discord-Bot/wiki/Changing-Application-State-Values-to-Custom-Text)", false, Subcategory: "Misc:more_vert:7")]


### PR DESCRIPTION
Added support for custom bot presence variables using `BotVariables.json`. 

Placeholders such as `{CustomValue}` can now be defined in the JSON file and automatically replaced in the configured bot presence text.

Example json:

```json
{
  "CustomValue": "value",
  "RestartCount": 4,
  "Maintenance": false
}
```

Resolves #220  